### PR TITLE
Add PWA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,14 @@ src/
 │   └── storyboard/         # Main storyboard interface
 └── static/                 # Static assets
 ```
+
+## Progressive Web App
+
+StoryMaker is a PWA. The app ships with a service worker that caches build assets for offline use and a web manifest so the site can be installed on desktop and mobile. The manifest reuses `static/favicon.png` for all icon sizes to avoid bundling extra binary assets.
+
+### Testing
+
+1. Run `npm run build` then `npm run preview` to serve the production build.
+2. Visit the site in Chrome and open DevTools > Application > Service Workers to ensure it is registered.
+3. Use Lighthouse to verify the PWA audit passes.
+4. Click the install button in the address bar or "Add to Home Screen" on mobile.

--- a/src/app.html
+++ b/src/app.html
@@ -3,7 +3,12 @@
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
+		<link rel="manifest" href="%sveltekit.assets%/manifest.webmanifest" />
+		<link rel="apple-touch-icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#1a1a1a" />
+		<meta name="mobile-web-app-capable" content="yes" />
+		<meta name="apple-mobile-web-app-capable" content="yes" />
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
 	import '../app.css';
+	import { onMount } from 'svelte';
 
 	let { children } = $props();
+
+	onMount(() => {
+		if ('serviceWorker' in navigator) {
+			navigator.serviceWorker.register('/service-worker.js');
+		}
+	});
 </script>
 
 {@render children()}

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -1,0 +1,34 @@
+/// <reference lib="webworker" />
+import { build, files, version } from '$service-worker';
+
+const CACHE = `cache-${version}`;
+const ASSETS = [...build, ...files];
+
+self.addEventListener('install', (event) => {
+	self.skipWaiting();
+	event.waitUntil(caches.open(CACHE).then((cache) => cache.addAll(ASSETS)));
+});
+
+self.addEventListener('activate', (event) => {
+	event.waitUntil(
+		caches
+			.keys()
+			.then((keys) =>
+				Promise.all(keys.filter((key) => key !== CACHE).map((key) => caches.delete(key)))
+			)
+	);
+});
+
+self.addEventListener('fetch', (event) => {
+	if (event.request.method !== 'GET') return;
+	event.respondWith(
+		caches.match(event.request).then((cached) => {
+			if (cached) return cached;
+			return fetch(event.request).then((response) => {
+				const clone = response.clone();
+				caches.open(CACHE).then((cache) => cache.put(event.request, clone));
+				return response;
+			});
+		})
+	);
+});

--- a/static/manifest.webmanifest
+++ b/static/manifest.webmanifest
@@ -1,0 +1,20 @@
+{
+	"name": "StoryMaker",
+	"short_name": "StoryMaker",
+	"start_url": "/",
+	"display": "standalone",
+	"background_color": "#ffffff",
+	"theme_color": "#1a1a1a",
+	"icons": [
+		{
+			"src": "/favicon.png",
+			"sizes": "192x192",
+			"type": "image/png"
+		},
+		{
+			"src": "/favicon.png",
+			"sizes": "512x512",
+			"type": "image/png"
+		}
+	]
+}


### PR DESCRIPTION
Summary
configure manifest and service worker for offline support
add icons for installation
register the service worker in the main layout
include PWA meta tags
document how to test PWA features
reuse existing favicon for icons to avoid binary files
Testing
npm run format
npm run lint
npm run build
https://chatgpt.com/codex/tasks/task_e_686bef9e9744832d83f9ae96adc53740