### PR TITLE
Improve PWA offline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ npm install
 # Start development server
 npm run dev
 
+# Serve over HTTPS for PWA testing
+npm run dev:https
+
 # Open in browser
 npm run dev -- --open
 ```
@@ -80,3 +83,16 @@ src/
 │   └── storyboard/         # Main storyboard interface
 └── static/                 # Static assets
 ```
+
+## Progressive Web App
+
+StoryMaker is a PWA. The service worker caches build assets and an offline fallback page so the app works without a network connection. A web manifest enables installability on desktop and mobile. Service workers run on `http://localhost`, but you can use HTTPS locally for a production-like install experience. The manifest reuses `static/favicon.png` for all icon sizes to avoid bundling extra binary assets.
+
+### Testing
+
+1. Run `npm run build` then `npm run preview` to serve the production build.
+   For a secure connection, use `npm run preview:https`.
+2. Visit the site in Chrome and open DevTools > Application > Service Workers to ensure it is registered.
+3. Use Lighthouse to verify the PWA audit passes.
+4. Disable your connection and reload the page to confirm the offline fallback displays.
+5. Click the install button in the address bar or "Add to Home Screen" on mobile.

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite dev",
+		"dev:https": "vite dev --https",
 		"build": "vite build",
 		"preview": "vite preview --port 5173",
+		"preview:https": "vite preview --https --port 5173",
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/src/app.html
+++ b/src/app.html
@@ -3,7 +3,12 @@
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
+		<link rel="manifest" href="%sveltekit.assets%/manifest.webmanifest" />
+		<link rel="apple-touch-icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#1a1a1a" />
+		<meta name="mobile-web-app-capable" content="yes" />
+		<meta name="apple-mobile-web-app-capable" content="yes" />
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,15 @@
 <script lang="ts">
 	import '../app.css';
+	import { onMount } from 'svelte';
 
 	let { children } = $props();
+
+	onMount(() => {
+		if ('serviceWorker' in navigator) {
+			const base = import.meta.env.BASE_URL;
+			navigator.serviceWorker.register(`${base}service-worker.js`);
+		}
+	});
 </script>
 
 {@render children()}

--- a/src/service-worker.ts
+++ b/src/service-worker.ts
@@ -1,0 +1,40 @@
+/// <reference lib="webworker" />
+import { build, files, version } from '$service-worker';
+
+const CACHE = `cache-${version}`;
+const ASSETS = [...build, ...files, '/offline.html'];
+
+self.addEventListener('install', (event) => {
+	self.skipWaiting();
+	event.waitUntil(caches.open(CACHE).then((cache) => cache.addAll(ASSETS)));
+});
+
+self.addEventListener('activate', (event) => {
+	event.waitUntil(
+		caches
+			.keys()
+			.then((keys) =>
+				Promise.all(keys.filter((key) => key !== CACHE).map((key) => caches.delete(key)))
+			)
+	);
+});
+
+self.addEventListener('fetch', (event) => {
+	if (event.request.method !== 'GET') return;
+
+	if (event.request.mode === 'navigate') {
+		event.respondWith(fetch(event.request).catch(() => caches.match('/offline.html')));
+		return;
+	}
+
+	event.respondWith(
+		caches.match(event.request).then((cached) => {
+			if (cached) return cached;
+			return fetch(event.request).then((response) => {
+				const clone = response.clone();
+				caches.open(CACHE).then((cache) => cache.put(event.request, clone));
+				return response;
+			});
+		})
+	);
+});

--- a/static/manifest.webmanifest
+++ b/static/manifest.webmanifest
@@ -1,0 +1,20 @@
+{
+	"name": "StoryMaker",
+	"short_name": "StoryMaker",
+	"start_url": "/",
+	"display": "standalone",
+	"background_color": "#ffffff",
+	"theme_color": "#1a1a1a",
+	"icons": [
+		{
+			"src": "/favicon.png",
+			"sizes": "192x192",
+			"type": "image/png"
+		},
+		{
+			"src": "/favicon.png",
+			"sizes": "512x512",
+			"type": "image/png"
+		}
+	]
+}

--- a/static/offline.html
+++ b/static/offline.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Offline - StoryMaker</title>
+		<style>
+			body {
+				font-family: system-ui, sans-serif;
+				display: flex;
+				justify-content: center;
+				align-items: center;
+				height: 100vh;
+				margin: 0;
+				background-color: #fafafa;
+			}
+			h1 {
+				color: #333;
+				font-size: 1.5rem;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>You are offline</h1>
+	</body>
+</html>


### PR DESCRIPTION
## Summary
- add offline fallback page and cache it in the service worker
- register the service worker using `import.meta.env.BASE_URL`
- document offline functionality in the README

## Testing
- `npm run format`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686bef9e9744832d83f9ae96adc53740