### PR TITLE
Added delete functionality

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -35,7 +35,7 @@ paths:
                 type: integer
                 description: The index at which to insert the new slide.
               newSlideOutline:
-                $ref: '#/components/s/SlideOutline'
+                $ref: '#/components/schemas/SlideOutline'
       responses:
         '200':
           description: Successfully added the slide and returned the storyboard ID.

--- a/e2e/mobile.test.ts
+++ b/e2e/mobile.test.ts
@@ -68,6 +68,8 @@ test.describe('Mobile Navigation - Dashboard', () => {
 		await page.getByRole('textbox', { name: 'Password' }).fill(password);
 		await page.getByRole('textbox', { name: 'Full Name' }).fill(fullName);
 		await page.getByRole('textbox', { name: 'Display Name' }).fill(displayName);
+		await expect(page.getByRole('button', { name: 'Create Account' })).toBeEnabled();
+		await expect(page.getByRole('button', { name: 'Create Account' })).toBeVisible();
 		await page.getByRole('button', { name: 'Create Account' }).click();
 
 		// Wait for redirect to login

--- a/src/lib/components/Storyboard/SlideModal.svelte
+++ b/src/lib/components/Storyboard/SlideModal.svelte
@@ -207,6 +207,36 @@
 		}
 	}
 
+	/**
+	 * Deletes the current slide after confirmation.
+	 */
+	async function deleteSlide() {
+		if (confirm('Are you sure you want to delete this slide?')) {
+			loading = true;
+			error = '';
+			try {
+				const res = await fetch('/api/storyboard/delete-slide', {
+					method: 'POST',
+					body: JSON.stringify({
+						storyboard_id: storyboard._id,
+						slideIndex: selectedSlideIndex
+					})
+				});
+				const data = await res.json();
+				if (res.ok) {
+					dispatch('update', data.storyboard);
+					closeModal();
+				} else {
+					error = data.error || 'Failed to delete slide';
+				}
+			} catch (e) {
+				error = e instanceof Error ? e.message : String(e);
+			} finally {
+				loading = false;
+			}
+		}
+	}
+
 	function cancelEdit() {
 		if (isNewSlide) {
 			closeModal();
@@ -297,6 +327,7 @@
 					>
 				{:else}
 					<button class="btn btn-primary" on:click={() => (editing = true)}>Edit</button>
+					<button class="btn btn-error" on:click={deleteSlide} disabled={loading}>Delete</button>
 				{/if}
 			</div>
 		</div>

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -155,6 +155,82 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /storyboard/add-slide:
+    post:
+      tags:
+        - Storyboard
+      summary: Add a new slide to a storyboard
+      description: Inserts a new slide outline at a specific index in a storyboard, re-indexing all subsequent slides.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                storyboard_id:
+                  type: string
+                  description: The ID of the storyboard to modify.
+                insertionIndex:
+                  type: integer
+                  description: The index at which to insert the new slide.
+                newSlideOutline:
+                  $ref: '#/components/schemas/SlideOutline'
+      responses:
+        '200':
+          description: Successfully added the slide and returned the storyboard ID.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+        '400':
+          description: Bad Request - Missing required fields.
+        '404':
+          description: Not Found - The specified storyboard could not be found.
+
+  /storyboard/delete-slide:
+    post:
+      tags:
+        - Storyboard
+      summary: Delete a slide from a storyboard
+      description: Deletes a slide at a specific index in a storyboard, re-indexing all subsequent slides.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                storyboard_id:
+                  type: string
+                  description: The ID of the storyboard to modify.
+                slideIndex:
+                  type: integer
+                  description: The index of the slide to delete.
+      responses:
+        '200':
+          description: Successfully deleted the slide and returned the updated storyboard.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  storyboard:
+                    $ref: '#/components/schemas/Storyboard'
+        '400':
+          description: Bad Request - Missing required fields.
+        '404':
+          description: Not Found - The specified storyboard could not be found.
+
   /storyboard/generate-game:
     post:
       tags:


### PR DESCRIPTION

# Pull Request

## 📋 Summary

Added delete functionality to the slides. Allows the deletion of slides only. 

## 🔍 Motivation and Context

Allows Users to have more edit functionality.

## 🛠 Changes

Added delete button and functionality. 

## ✅ Checklist

- [x] Code follows the project style guidelines and passed linting checks
- [x] Passes type checks
- [] Tests have been added or updated to cover these changes
- [x] Documentation has been updated where appropriate
- [x] All new and existing tests pass

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added the ability to delete slides from a storyboard, including a delete button in the slide modal and a new API endpoint for slide deletion.

- **New Features**
  - Added a delete button to the slide modal for removing slides.
  - Implemented backend API to handle slide deletion and re-indexing.
  - Updated API documentation to include the new delete-slide endpoint.

<!-- End of auto-generated description by cubic. -->

