### PR TITLE
Add Storyboard Deletion Feature

### DIFF
--- a/src/lib/components/Dashboard/Storyboards.svelte
+++ b/src/lib/components/Dashboard/Storyboards.svelte
@@ -34,12 +34,7 @@
 	teamStore.set(team ? team : null);
 
 	// Create a reactive local copy of storyboards for proper UI updates
-	let localStoryboards = $state(storyboards);
-
-	// Update local copy when props change
-	$effect(() => {
-		localStoryboards = storyboards;
-	});
+	let localStoryboards = $derived(storyboards);
 
 	// State management
 	let selectedStoryboard = $state<Storyboard | null>(null);

--- a/src/lib/components/Dashboard/Storyboards.svelte
+++ b/src/lib/components/Dashboard/Storyboards.svelte
@@ -35,7 +35,7 @@
 
 	// Create a reactive local copy of storyboards for proper UI updates
 	let localStoryboards = $state(storyboards);
-	
+
 	// Update local copy when props change
 	$effect(() => {
 		localStoryboards = storyboards;
@@ -86,10 +86,10 @@
 			if (response.ok) {
 				// Close the modal first
 				showDeleteModal = null;
-				
+
 				// Immediately remove from local state for responsive UI
 				localStoryboards = localStoryboards.filter((s) => s._id !== storyboard._id);
-				
+
 				// Invalidate the dashboard data to refresh from server
 				await invalidate('dashboard:storyboards');
 			} else {

--- a/src/lib/components/Dashboard/Storyboards.svelte
+++ b/src/lib/components/Dashboard/Storyboards.svelte
@@ -76,7 +76,7 @@
 
 			if (response.ok) {
 				// Remove from local state
-				storyboards = storyboards.filter(s => s._id !== storyboard._id);
+				storyboards = storyboards.filter((s) => s._id !== storyboard._id);
 				showDeleteModal = null;
 			} else {
 				const error = await response.json();
@@ -548,10 +548,13 @@
 
 			<div class="mb-6">
 				<p class="text-base-content mb-4">
-					Are you sure you want to delete <strong>"{showDeleteModal.storyOutline.storyMetadata.title}"</strong>?
+					Are you sure you want to delete <strong
+						>"{showDeleteModal.storyOutline.storyMetadata.title}"</strong
+					>?
 				</p>
 				<p class="text-base-content/70 text-sm">
-					This action cannot be undone. All slides, images, and generated games will be permanently deleted.
+					This action cannot be undone. All slides, images, and generated games will be permanently
+					deleted.
 				</p>
 			</div>
 

--- a/src/lib/components/Storyboard/SlideModal.svelte
+++ b/src/lib/components/Storyboard/SlideModal.svelte
@@ -330,7 +330,9 @@
 					>
 				{:else}
 					<button class="btn btn-primary" on:click={() => (editing = true)}>Edit</button>
-					<button class="btn btn-error" on:click={deleteSlide} disabled={loading}>Delete</button>
+					{#if !isNewSlide}
+						<button class="btn btn-error" on:click={deleteSlide} disabled={loading}>Delete</button>
+					{/if}
 				{/if}
 			</div>
 		</div>

--- a/src/routes/api/storyboard/delete-slide/+server.ts
+++ b/src/routes/api/storyboard/delete-slide/+server.ts
@@ -2,44 +2,120 @@
  * @file Handles the deletion of a slide from an existing storyboard.
  */
 import { json } from '@sveltejs/kit';
-import { getDB } from '$lib/server/db';
+import { initDB } from '$lib/server/db';
 import { ObjectId } from 'mongodb';
+import type { RequestHandler } from '@sveltejs/kit';
+import { getUserFromEvent } from '$lib/server/userService';
 import type { Storyboard } from '$lib/models/storyboard.model';
+
+interface DeleteSlideRequest {
+	storyboard_id: string;
+	slideIndex: number;
+}
 
 /**
  * @description Deletes a slide at a specified index in a storyboard.
  * @param {RequestEvent} event - The SvelteKit request event.
  * @returns {Promise<Response>} A JSON response containing the updated storyboard or an error.
  */
-export async function POST({ request }) {
-	const { storyboard_id, slideIndex } = await request.json();
+export const POST: RequestHandler = async (event) => {
+	const { storyboard_id, slideIndex } = (await event.request.json()) as DeleteSlideRequest;
 
 	if (!storyboard_id || slideIndex === undefined) {
-		return json({ error: 'Missing required fields' }, { status: 400 });
+		return json({ error: 'Missing storyboard_id or slideIndex' }, { status: 400 });
 	}
 
-	const db = await getDB();
-	const storyboard = (await db
-		.collection('storyboards')
-		.findOne({ _id: new ObjectId(storyboard_id) })) as Storyboard | null;
-
-	if (!storyboard) {
-		return json({ error: 'Storyboard not found' }, { status: 404 });
+	const user = await getUserFromEvent(event);
+	if (!user) {
+		return json({ error: 'User not found' }, { status: 404 });
 	}
 
-	// Remove the slide
-	storyboard.storyOutline.slideOutlines.splice(slideIndex, 1);
-	storyboard.visualSlides.splice(slideIndex, 1);
+	const db = await initDB();
 
-	// Re-index subsequent slides
-	for (let i = slideIndex; i < storyboard.storyOutline.slideOutlines.length; i++) {
-		storyboard.storyOutline.slideOutlines[i].slideId = i + 1;
-		storyboard.visualSlides[i].slideNumber = i + 1;
+	try {
+		// Get the current storyboard
+		const storyboard = (await db
+			.collection('storyboards')
+			.findOne({ _id: new ObjectId(storyboard_id) })) as Storyboard | null;
+
+		if (!storyboard) {
+			return json({ error: 'Storyboard not found' }, { status: 404 });
+		}
+
+		// Check if user has permission to modify this storyboard
+		const userProjects = user.projects as string[];
+		const userTeams = await db.collection('teams').find({ 'users.user': user._id }).toArray();
+
+		const teamProjects = userTeams.flatMap((team) => team.projects as string[]);
+		const allAccessibleProjects = [...userProjects, ...teamProjects];
+
+		if (!allAccessibleProjects.includes(storyboard_id)) {
+			return json({ error: 'Permission denied' }, { status: 403 });
+		}
+
+		// Validate slide index
+		if (slideIndex < 0 || slideIndex >= storyboard.storyOutline.slideOutlines.length) {
+			return json({ error: 'Invalid slide index' }, { status: 400 });
+		}
+
+		// Prevent deleting the last slide (must have at least 1 slide)
+		if (storyboard.storyOutline.slideOutlines.length <= 1) {
+			return json(
+				{ error: 'Cannot delete the last slide. Storyboard must have at least one slide.' },
+				{ status: 400 }
+			);
+		}
+
+		// Remove the slide from slideOutlines
+		const updatedSlideOutlines = [...storyboard.storyOutline.slideOutlines];
+		updatedSlideOutlines.splice(slideIndex, 1);
+
+		// Reorder slideIds to be sequential starting from 1
+		updatedSlideOutlines.forEach((slide, index) => {
+			slide.slideId = index + 1;
+		});
+
+		// Remove the corresponding visual slide
+		const updatedVisualSlides = [...storyboard.visualSlides];
+		updatedVisualSlides.splice(slideIndex, 1);
+
+		// Reorder visual slide numbers to be sequential starting from 1
+		updatedVisualSlides.forEach((slide, index) => {
+			slide.slideNumber = index + 1;
+		});
+
+		// Update the storyboard in the database
+		const updateResult = await db.collection('storyboards').updateOne(
+			{ _id: new ObjectId(storyboard_id) },
+			{
+				$set: {
+					'storyOutline.slideOutlines': updatedSlideOutlines,
+					visualSlides: updatedVisualSlides,
+					updatedAt: new Date()
+				},
+				$unset: {
+					gameHtml: '',
+					interactions: ''
+				}
+			}
+		);
+
+		if (updateResult.matchedCount === 0) {
+			return json({ error: 'Failed to update storyboard' }, { status: 500 });
+		}
+
+		// Fetch the updated storyboard to return
+		const updatedStoryboard = (await db
+			.collection('storyboards')
+			.findOne({ _id: new ObjectId(storyboard_id) })) as Storyboard;
+
+		return json({
+			success: true,
+			message: 'Slide deleted successfully',
+			storyboard: updatedStoryboard
+		});
+	} catch (err) {
+		console.error('Failed to delete slide:', err);
+		return json({ error: 'Database operation failed' }, { status: 500 });
 	}
-
-	await db
-		.collection('storyboards')
-		.updateOne({ _id: new ObjectId(storyboard_id) }, { $set: storyboard });
-
-	return json({ success: true, storyboard });
-}
+};

--- a/src/routes/api/storyboard/delete/+server.ts
+++ b/src/routes/api/storyboard/delete/+server.ts
@@ -12,7 +12,7 @@ interface DeleteStoryboardRequest {
 
 export const DELETE: RequestHandler = async (event) => {
 	const { storyboardId } = (await event.request.json()) as DeleteStoryboardRequest;
-	
+
 	if (!storyboardId) {
 		return json({ error: 'Missing storyboardId' }, { status: 400 });
 	}
@@ -23,13 +23,13 @@ export const DELETE: RequestHandler = async (event) => {
 	}
 
 	const db = await initDB();
-	
+
 	try {
 		// Check if storyboard exists and user has access to it
 		const storyboard = await db
 			.collection('storyboards')
 			.findOne({ _id: new ObjectId(storyboardId) });
-		
+
 		if (!storyboard) {
 			return json({ error: 'Storyboard not found' }, { status: 404 });
 		}
@@ -37,14 +37,11 @@ export const DELETE: RequestHandler = async (event) => {
 		// Check if user has permission to delete this storyboard
 		// (User should own it or be part of a team that owns it)
 		const userProjects = user.projects as string[];
-		const userTeams = await db
-			.collection('teams')
-			.find({ 'users.user': user._id })
-			.toArray();
-		
-		const teamProjects = userTeams.flatMap(team => team.projects as string[]);
+		const userTeams = await db.collection('teams').find({ 'users.user': user._id }).toArray();
+
+		const teamProjects = userTeams.flatMap((team) => team.projects as string[]);
 		const allAccessibleProjects = [...userProjects, ...teamProjects];
-		
+
 		if (!allAccessibleProjects.includes(storyboardId)) {
 			return json({ error: 'Permission denied' }, { status: 403 });
 		}
@@ -59,16 +56,16 @@ export const DELETE: RequestHandler = async (event) => {
 		}
 
 		// Remove storyboard from user's projects
-		await db.collection('users').updateOne(
-			{ _id: new ObjectId(user._id) },
-			{ $pull: { projects: storyboardId } } as any
-		);
+		await db
+			.collection('users')
+			.updateOne({ _id: new ObjectId(user._id) }, { $pull: { projects: storyboardId } } as any);
 
 		// Remove storyboard from all teams that have it
-		await db.collection('teams').updateMany(
-			{ projects: { $in: [storyboardId] } },
-			{ $pull: { projects: storyboardId } } as any
-		);
+		await db
+			.collection('teams')
+			.updateMany({ projects: { $in: [storyboardId] } }, {
+				$pull: { projects: storyboardId }
+			} as any);
 
 		// Clean up generated game files if they exist
 		try {

--- a/src/routes/api/storyboard/delete/+server.ts
+++ b/src/routes/api/storyboard/delete/+server.ts
@@ -56,14 +56,16 @@ export const DELETE: RequestHandler = async (event) => {
 		}
 
 		// Remove storyboard from user's projects
-		await db
-			.collection('users')
-			.updateOne({ _id: new ObjectId(user._id) }, { $pull: { projects: storyboardId } } as any);
+		await db.collection('users').updateOne(
+			{ _id: new ObjectId(user._id) },
+			{ $pull: { projects: storyboardId } } as { $pull: { projects: string } }
+		);
 
 		// Remove storyboard from all teams that have it
-		await db.collection('teams').updateMany({ projects: { $in: [storyboardId] } }, {
-			$pull: { projects: storyboardId }
-		} as any);
+		await db.collection('teams').updateMany(
+			{ projects: { $in: [storyboardId] } },
+			{ $pull: { projects: storyboardId } } as { $pull: { projects: string } }
+		);
 
 		// Clean up generated game files if they exist
 		try {

--- a/src/routes/api/storyboard/delete/+server.ts
+++ b/src/routes/api/storyboard/delete/+server.ts
@@ -61,11 +61,9 @@ export const DELETE: RequestHandler = async (event) => {
 			.updateOne({ _id: new ObjectId(user._id) }, { $pull: { projects: storyboardId } } as object);
 
 		// Remove storyboard from all teams that have it
-		await db
-			.collection('teams')
-			.updateMany({ projects: { $in: [storyboardId] } }, {
-				$pull: { projects: storyboardId }
-			} as object);
+		await db.collection('teams').updateMany({ projects: { $in: [storyboardId] } }, {
+			$pull: { projects: storyboardId }
+		} as object);
 
 		// Clean up generated game files if they exist
 		try {

--- a/src/routes/api/storyboard/delete/+server.ts
+++ b/src/routes/api/storyboard/delete/+server.ts
@@ -56,15 +56,15 @@ export const DELETE: RequestHandler = async (event) => {
 		}
 
 		// Remove storyboard from user's projects
-		await (db.collection('users') as any).updateOne(
+		await db.collection('users').updateOne(
 			{ _id: new ObjectId(user._id) },
-			{ $pull: { projects: storyboardId } }
+			{ $pull: { projects: storyboardId } } as object
 		);
 
 		// Remove storyboard from all teams that have it
-		await (db.collection('teams') as any).updateMany(
+		await db.collection('teams').updateMany(
 			{ projects: { $in: [storyboardId] } },
-			{ $pull: { projects: storyboardId } }
+			{ $pull: { projects: storyboardId } } as object
 		);
 
 		// Clean up generated game files if they exist

--- a/src/routes/api/storyboard/delete/+server.ts
+++ b/src/routes/api/storyboard/delete/+server.ts
@@ -56,15 +56,15 @@ export const DELETE: RequestHandler = async (event) => {
 		}
 
 		// Remove storyboard from user's projects
-		await db.collection('users').updateOne(
+		await (db.collection('users') as any).updateOne(
 			{ _id: new ObjectId(user._id) },
-			{ $pull: { projects: storyboardId } } as { $pull: { projects: string } }
+			{ $pull: { projects: storyboardId } }
 		);
 
 		// Remove storyboard from all teams that have it
-		await db.collection('teams').updateMany(
+		await (db.collection('teams') as any).updateMany(
 			{ projects: { $in: [storyboardId] } },
-			{ $pull: { projects: storyboardId } } as { $pull: { projects: string } }
+			{ $pull: { projects: storyboardId } }
 		);
 
 		// Clean up generated game files if they exist

--- a/src/routes/api/storyboard/delete/+server.ts
+++ b/src/routes/api/storyboard/delete/+server.ts
@@ -61,11 +61,9 @@ export const DELETE: RequestHandler = async (event) => {
 			.updateOne({ _id: new ObjectId(user._id) }, { $pull: { projects: storyboardId } } as any);
 
 		// Remove storyboard from all teams that have it
-		await db
-			.collection('teams')
-			.updateMany({ projects: { $in: [storyboardId] } }, {
-				$pull: { projects: storyboardId }
-			} as any);
+		await db.collection('teams').updateMany({ projects: { $in: [storyboardId] } }, {
+			$pull: { projects: storyboardId }
+		} as any);
 
 		// Clean up generated game files if they exist
 		try {

--- a/src/routes/api/storyboard/delete/+server.ts
+++ b/src/routes/api/storyboard/delete/+server.ts
@@ -1,0 +1,90 @@
+import { json } from '@sveltejs/kit';
+import { initDB } from '$lib/server/db';
+import { ObjectId } from 'mongodb';
+import type { RequestHandler } from '@sveltejs/kit';
+import { getUserFromEvent } from '$lib/server/userService';
+import fs from 'fs';
+import path from 'path';
+
+interface DeleteStoryboardRequest {
+	storyboardId: string;
+}
+
+export const DELETE: RequestHandler = async (event) => {
+	const { storyboardId } = (await event.request.json()) as DeleteStoryboardRequest;
+	
+	if (!storyboardId) {
+		return json({ error: 'Missing storyboardId' }, { status: 400 });
+	}
+
+	const user = await getUserFromEvent(event);
+	if (!user) {
+		return json({ error: 'User not found' }, { status: 404 });
+	}
+
+	const db = await initDB();
+	
+	try {
+		// Check if storyboard exists and user has access to it
+		const storyboard = await db
+			.collection('storyboards')
+			.findOne({ _id: new ObjectId(storyboardId) });
+		
+		if (!storyboard) {
+			return json({ error: 'Storyboard not found' }, { status: 404 });
+		}
+
+		// Check if user has permission to delete this storyboard
+		// (User should own it or be part of a team that owns it)
+		const userProjects = user.projects as string[];
+		const userTeams = await db
+			.collection('teams')
+			.find({ 'users.user': user._id })
+			.toArray();
+		
+		const teamProjects = userTeams.flatMap(team => team.projects as string[]);
+		const allAccessibleProjects = [...userProjects, ...teamProjects];
+		
+		if (!allAccessibleProjects.includes(storyboardId)) {
+			return json({ error: 'Permission denied' }, { status: 403 });
+		}
+
+		// Delete the storyboard from database
+		const deleteResult = await db
+			.collection('storyboards')
+			.deleteOne({ _id: new ObjectId(storyboardId) });
+
+		if (deleteResult.deletedCount === 0) {
+			return json({ error: 'Failed to delete storyboard' }, { status: 500 });
+		}
+
+		// Remove storyboard from user's projects
+		await db.collection('users').updateOne(
+			{ _id: new ObjectId(user._id) },
+			{ $pull: { projects: storyboardId } } as any
+		);
+
+		// Remove storyboard from all teams that have it
+		await db.collection('teams').updateMany(
+			{ projects: { $in: [storyboardId] } },
+			{ $pull: { projects: storyboardId } } as any
+		);
+
+		// Clean up generated game files if they exist
+		try {
+			const gameDir = path.join('static', 'games', storyboardId);
+			if (fs.existsSync(gameDir)) {
+				fs.rmSync(gameDir, { recursive: true, force: true });
+				console.log(`Cleaned up game files for storyboard ${storyboardId}`);
+			}
+		} catch (cleanupError) {
+			console.warn(`Failed to clean up game files for ${storyboardId}:`, cleanupError);
+			// Don't fail the delete operation if cleanup fails
+		}
+
+		return json({ success: true, message: 'Storyboard deleted successfully' });
+	} catch (err) {
+		console.error('Failed to delete storyboard:', err);
+		return json({ error: 'Database operation failed' }, { status: 500 });
+	}
+};

--- a/src/routes/api/storyboard/delete/+server.ts
+++ b/src/routes/api/storyboard/delete/+server.ts
@@ -56,16 +56,16 @@ export const DELETE: RequestHandler = async (event) => {
 		}
 
 		// Remove storyboard from user's projects
-		await db.collection('users').updateOne(
-			{ _id: new ObjectId(user._id) },
-			{ $pull: { projects: storyboardId } } as object
-		);
+		await db
+			.collection('users')
+			.updateOne({ _id: new ObjectId(user._id) }, { $pull: { projects: storyboardId } } as object);
 
 		// Remove storyboard from all teams that have it
-		await db.collection('teams').updateMany(
-			{ projects: { $in: [storyboardId] } },
-			{ $pull: { projects: storyboardId } } as object
-		);
+		await db
+			.collection('teams')
+			.updateMany({ projects: { $in: [storyboardId] } }, {
+				$pull: { projects: storyboardId }
+			} as object);
 
 		// Clean up generated game files if they exist
 		try {


### PR DESCRIPTION
## Description
This PR adds the ability to delete storyboards from the dashboard, including proper cleanup of associated data and files.

## Changes
- Added a delete button to each storyboard card in the dashboard
- Implemented a confirmation modal to prevent accidental deletions
- Created a new API endpoint at `/api/storyboard/delete` to handle storyboard deletion
- Added server-side validation to ensure users can only delete their own storyboards
- Implemented cleanup of associated game files and database references

## Technical Details
- Frontend: Added a delete button with confirmation modal in [Storyboards.svelte](cci:7://file:///c:/Users/annav/Documents/Github_Repos/StoryMaker/Pro0623-StoryMaker/src/lib/components/Dashboard/Storyboards.svelte:0:0-0:0)
- Backend: Created a new DELETE endpoint that:
  - Validates user permissions
  - Removes the storyboard from the database
  - Cleans up associated game files
  - Updates user and team references
- Added error handling and user feedback

## Testing
- [x] Verify that only storyboard owners can delete their storyboards
- [x] Test that the confirmation modal appears before deletion
- [x] Confirm that all associated data is properly cleaned up
- [x] Verify
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added the ability to delete storyboards from the dashboard, including a confirmation modal and full cleanup of related data and files.

- **New Features**
  - Delete button on each storyboard card with a confirmation modal.
  - Only storyboard owners can delete.
  - Associated game files and database references are removed.

<!-- End of auto-generated description by cubic. -->

